### PR TITLE
Introduce Intel NUC device support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,10 @@ Work in progress to adapt device specific and customer-specific out-of-tree conf
 
 #### Build image using specific configuration:
 While in build directory, run
-
-    $ nix-build -I nixpkgs=nixpkgs -I spectrum-config=build-configurations/imx8qm-config.nix build-configurations/release/live/
+| Target device | Build command |
+| -------- | ----------- |
+| imx8qm-mek | `nix-build -I nixpkgs=nixpkgs -I spectrum-config=build-configurations/imx8qm-config.nix build-configurations/release/live/` |
+| Intel NUC | `nix-build -I nixpkgs=nixpkgs -I spectrum-config=build-configurations/x86-nuc-config.nix build-configurations/release/live/` |
 
 You can add `nixpkgs` and `spectrum-config` variables to your `NIX_PATH`
 
@@ -35,9 +37,7 @@ Put SD card into the board and switch it on. You should see a lovely Spectrum de
 
 ## Temporary limitations and known issues
 
-1. Currently the only device supported is `imx8qm-evk`, more devices very soon!
-2. There is no cross-compilation support (yet). Use native `aarch64` hardware to build the image.
-3. There are still some hardware-specific parts that need to be reworked.
+1. There is no cross-compilation support (yet). Use native `aarch64` hardware to build image for `imx8qm-mek`.
 
 ## More info
 

--- a/overlays/common.nix
+++ b/overlays/common.nix
@@ -2,4 +2,6 @@
 final: prev: {
   crosvm = final.callPackage ./packages/crosvm { inherit (prev) crosvm; };
   usbutils = final.callPackage ./packages/usbutils {inherit (prev) usbutils; };
+  spectrum-rootfs = import ../../spectrum/host/rootfs { };
+  spectrum-live = import ../../spectrum/release/live { };
 }

--- a/overlays/imx8qm.nix
+++ b/overlays/imx8qm.nix
@@ -2,4 +2,35 @@
 final: prev: {
   linux_imx8 = final.callPackage ./bsp/kernel/linux-imx8 { pkgs = final; };
   inherit ( final.callPackage ./bsp/u-boot/imx8qm/imx-uboot.nix { pkgs = final; }) ubootImx8 imx-firmware;
+
+  spectrum-live = prev.spectrum-live.overrideAttrs (old: {
+    KERNEL = final.linux_imx8;
+    pname = "build/live.img";
+    # The beginning of the first partition should be moved
+    # because u-boot overwrites it (the size of u-boot is bigger
+    # than the gap between GPT table and first partition (4Mb))
+    # It was decided that 10Mb of space will be enough for u-boot,
+    # so let's move all partitions by additional 6Mb to the right.
+    installPhase = ''
+      runHook preInstall
+      dd if=/dev/zero bs=1M count=6 >> $pname
+      partnum=$(sfdisk --json $pname | grep "node" | wc -l)
+      while [ $partnum -gt 0 ]; do
+        echo '+6M,' | sfdisk --move-data $pname -N $partnum
+        partnum=$((partnum-1))
+      done
+      dd if=${final.ubootImx8}/flash.bin of=$pname bs=1k seek=32 conv=notrunc
+      IMG=$pname
+      ESP_OFFSET=$(sfdisk --json $IMG | jq -r '
+        # Partition type GUID identifying EFI System Partitions
+        def ESP_GUID: "C12A7328-F81F-11D2-BA4B-00A0C93EC93B";
+        .partitiontable |
+        .sectorsize * (.partitions[] | select(.type == ESP_GUID) | .start)
+      ')
+      mcopy -no -i $pname@@$ESP_OFFSET $KERNEL/dtbs/freescale/imx8qm-mek-hdmi.dtb ::/
+      mcopy -no -i $pname@@$ESP_OFFSET ${final.imx-firmware}/hdmitxfw.bin ::/
+      mv $pname $out
+      runHook postInstall
+    '';
+  });
 }

--- a/overlays/intel-nuc.nix
+++ b/overlays/intel-nuc.nix
@@ -1,0 +1,12 @@
+
+final: prev: {
+    spectrum-rootfs = prev.spectrum-rootfs.overrideAttrs (old: {
+        # TODO move this feature to the future "development" release.
+        # This patch allows to use serial console through USB interface of NUC
+        # device.
+        patches = [ ./patches/0001-Open-USB-serial-terminal-at-boot.patch ];
+    });
+    spectrum-live = prev.spectrum-live.overrideAttrs (old: {
+        ROOT_FS = final.spectrum-rootfs;
+    });
+}

--- a/overlays/patches/0001-Open-USB-serial-terminal-at-boot.patch
+++ b/overlays/patches/0001-Open-USB-serial-terminal-at-boot.patch
@@ -1,0 +1,32 @@
+commit 4b4ab8aee8f8cf8a8213c8aa43eab455f74afe7f
+Author: Tero Tervala <tero.tervala@unikie.com>
+Date:   Fri Jun 3 13:37:47 2022 +0300
+
+    Open USB serial terminal at boot
+
+    Signed-off-by: Tero Tervala <tero.tervala@unikie.com>
+
+diff --git a/Makefile b/Makefile
+index f0f6a4b..b68b00b 100644
+--- a/Makefile
++++ b/Makefile
+@@ -36,7 +36,7 @@ FILES = \
+	etc/s6-linux-init/run-image/service/getty-tty2/run \
+	etc/s6-linux-init/run-image/service/getty-tty3/run \
+	etc/s6-linux-init/run-image/service/getty-tty4/run \
+-	etc/s6-linux-init/run-image/service/getty-ttyS0/run \
++	etc/s6-linux-init/run-image/service/getty-ttyUSB0/run \
+	etc/s6-linux-init/scripts/rc.init \
+	etc/xdg/weston/autolaunch \
+	etc/xdg/weston/weston.ini \
+diff --git a/host/rootfs/etc/s6-linux-init/run-image/service/getty-ttyUSB0/run b/host/rootfs/etc/s6-linux-init/run-image/service/getty-ttyUSB0/run
+new file mode 100755
+index 0000000..9730b19
+--- /dev/null
++++ b/etc/s6-linux-init/run-image/service/getty-ttyUSB0/run
+@@ -0,0 +1,5 @@
++#!/bin/execlineb -P
++# SPDX-License-Identifier: EUPL-1.2
++# SPDX-FileCopyrightText: 2021-2022 Tero Tervala <tero.tervala@unikie.com>
++
++getty -i -n -l /etc/login 115200 ttyUSB0 dumb

--- a/release/live/default.nix
+++ b/release/live/default.nix
@@ -1,10 +1,9 @@
 # SPDX-FileCopyrightText: 2022 Unikie
 
-{ config ? import ../../../spectrum/nix/eval-config.nix {}, hostKernel ? null }:
+{ config ? import ../../../spectrum/nix/eval-config.nix {} }:
 
 let
   inherit (config) pkgs;
-  spectrum = import ../../../spectrum/release/live { };
   appvm-zathura = pkgs.callPackage ../../vm/zathura { inherit config; };
   usbvm = pkgs.callPackage ../../vm/usb { inherit config; };
   usbappvm = pkgs.callPackage ../../vm/usbapp {inherit config; };
@@ -18,7 +17,7 @@ let
         ${kmod}/bin/modprobe ext4
 
         cd /tmp/xchg
-        install -m 0644 ${spectrum.EXT_FS} user-ext.ext4
+        install -m 0644 ${spectrum-live.EXT_FS} user-ext.ext4
         spaceInMiB=$(du -sB M ${appvm-zathura} | awk '{ print substr( $1, 1, length($1)-1 ) }')
         dd if=/dev/zero bs=1M count=$(expr $spaceInMiB + 50) >> user-ext.ext4
         spaceInMiB=$(du -sB M ${usbvm} | awk '{ print substr( $1, 1, length($1)-1 ) }')
@@ -44,29 +43,7 @@ let
 in
 with pkgs;
 
-spectrum.overrideDerivation (oldAttrs: {
+spectrum-live.overrideAttrs (oldAttrs: {
   EXT_FS = myextpart;
-  KERNEL = linux_imx8;
-  pname = "build/live.img";
-  installPhase = ''
-    runHook preInstall
-    dd if=/dev/zero bs=1M count=6 >> $pname
-    partnum=$(sfdisk --json $pname | grep "node" | wc -l)
-    while [ $partnum -gt 0 ]; do
-      echo '+6M,' | sfdisk --move-data $pname -N $partnum
-      partnum=$((partnum-1))
-    done
-    dd if=${ubootImx8}/flash.bin of=$pname bs=1k seek=32 conv=notrunc
-    IMG=$pname
-    ESP_OFFSET=$(sfdisk --json $IMG | jq -r '
-      # Partition type GUID identifying EFI System Partitions
-      def ESP_GUID: "C12A7328-F81F-11D2-BA4B-00A0C93EC93B";
-      .partitiontable |
-      .sectorsize * (.partitions[] | select(.type == ESP_GUID) | .start)
-    ')
-    mcopy -no -i $pname@@$ESP_OFFSET $KERNEL/dtbs/freescale/imx8qm-mek-hdmi.dtb ::/
-    mcopy -no -i $pname@@$ESP_OFFSET ${imx-firmware}/hdmitxfw.bin ::/
-    mv $pname $out
-    runHook postInstall
-  '';
+  ROOT_FS = spectrum-rootfs;
 })

--- a/vm/usb/Makefile
+++ b/vm/usb/Makefile
@@ -14,7 +14,7 @@ SCRIPTS = ../../../scripts
 
 HOST_BUILD_FILES = \
 	build/host/data/appvm-usb/blk/root.img \
-	build/host/data/appvm-usb/Image\
+	build/host/data/appvm-usb/vmlinux \
         build/host/data/appvm-usb/providers/usb/
 
 
@@ -31,9 +31,9 @@ build/svc: $(HOST_BUILD_FILES) $(HOST_FILES)
 
 	tar -c $(HOST_BUILD_FILES) | tar -C $@ -x --strip-components 2
 
-build/host/data/appvm-usb/Image: $(IMAGE)
+build/host/data/appvm-usb/vmlinux: $(VMLINUX)
 	mkdir -p $$(dirname $@)
-	cp $(IMAGE) $$(dirname $@)/Image
+	cp $(VMLINUX) $@
 
 build/host/data/appvm-usb/blk/root.img: $(SCRIPTS)/make-gpt.sh $(SCRIPTS)/sfdisk-field.awk build/rootfs.ext4
 	mkdir -p $$(dirname $@)

--- a/vm/usb/default.nix
+++ b/vm/usb/default.nix
@@ -60,7 +60,7 @@ let
         -T ${writeReferencesToFile packagesSysroot} .
   '';
 
-  kernel = config.pkgs.linux_latest.override {
+  kernel = buildPackages.linux.override {
     structuredExtraConfig = with lib.kernel; {
       EFI_STUB=yes;
       EFI=yes;
@@ -101,7 +101,6 @@ stdenvNoCC.mkDerivation {
 
   PACKAGES_TAR = packagesTar;
   VMLINUX = "${kernel.dev}/vmlinux";
-  IMAGE = "${kernel}/Image";
 
   makeFlags = [ "SCRIPTS=${scripts}" ];
 

--- a/x86-nuc-config.nix
+++ b/x86-nuc-config.nix
@@ -1,0 +1,8 @@
+{
+  pkgs = import <nixpkgs> {
+    overlays = [
+      (import ./overlays/common.nix)
+      (import ./overlays/intel-nuc.nix)
+    ];
+  };
+}


### PR DESCRIPTION
This PR makes possible to build Spectrum OS image with custom VMs using `x86-nuc-config.nix` config file.