### PR TITLE
update: instructions configuration template to imx8qm

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Work in progress to adapt device specific and customer-specific out-of-tree conf
 #### Build image using specific configuration:
 While in build directory, run
 
-    $ nix-build -I nixpkgs=nixpkgs -I spectrum-config=build-configurations/<config-name>.nix build-configurations/release/live/
+    $ nix-build -I nixpkgs=nixpkgs -I spectrum-config=build-configurations/imx8qm-config.nix build-configurations/release/live/
 
 You can add `nixpkgs` and `spectrum-config` variables to your `NIX_PATH`
 


### PR DESCRIPTION
* as there is currently no other configuration, let's use imx8qm-config.nix instead of abstract template config.  It's easier for users to copy-paste to shell.