### PR TITLE
Fix imx8qm build

### DIFF
--- a/overlays/bsp/kernel/linux-imx8/default.nix
+++ b/overlays/bsp/kernel/linux-imx8/default.nix
@@ -3,8 +3,8 @@
 with pkgs;
 
 buildLinux (args // rec {
-  version = "5.15.32";
-  nxp_ref = "lf-5.15.y";
+  version = "5.15.71";
+  nxp_ref = "refs/tags/lf-5.15.71-2.2.0";
 
   # modDirVersion needs to be x.y.z, will automatically add .0 if needed
   modDirVersion = version;
@@ -41,7 +41,7 @@ buildLinux (args // rec {
   '';
 
   src = builtins.fetchGit {
-    url = "https://source.codeaurora.org/external/imx/linux-imx";
+    url = "https://github.com/nxp-imx/linux-imx";
     ref = nxp_ref;
   };
 } // (args.argsOverride or { }))

--- a/overlays/patches/0002-Fix-console-liveimg-for-imx8qm.patch
+++ b/overlays/patches/0002-Fix-console-liveimg-for-imx8qm.patch
@@ -6,7 +6,7 @@ index e63c598..2120e2d 100644
  	printf "title Spectrum\n" > $@
  	printf "linux /spectrum/linux\n" >> $@
  	printf "initrd /spectrum/initrd\n" >> $@
--	printf "options ro console=tty console=ttyS0 roothash=" >> $@
+-	printf "options ro console=tty console=ttyS0 intel_iommu=on roothash=" >> $@
 +	printf "options ro console=tty console=ttyLP0,115200 roothash=" >> $@
  	cat build/rootfs.verity.roothash >> $@
  


### PR DESCRIPTION
With the latest nixpkgs update NXP kernel lf-5.15.y fails to build. Updating the kernel to the latest version resolves this issue.

Signed-off-by: Yuri Nesterov <yuriy.nesterov@unikie.com>